### PR TITLE
Fix type of duration

### DIFF
--- a/lib/benchmark_driver.rb
+++ b/lib/benchmark_driver.rb
@@ -16,7 +16,7 @@ class BenchmarkDriver
       abort "unsupported measure type: #{measure_type.dump}"
     end
     @measure_type = measure_type
-    @measure_num = measure_num
+    @measure_num = measure_num.to_i
     @execs = execs.map do |exec|
       name, path = exec.split('::', 2)
       Executable.new(name, path || name)


### PR DESCRIPTION
I change duration by `-i DURATION`, then benchmark driver raises NoMethodError.
I have fixed it.

```
$ benchmark_driver ruby_benchmark_set/example_single.yml -i 1
```

```
/path/to/benchmark_driver/lib/benchmark_driver.rb:68:in `calc_iterations': undefined method `/' for "1":String (NoMethodError)
```