### PR TITLE
Show clocks

### DIFF
--- a/lib/benchmark/output/ips.rb
+++ b/lib/benchmark/output/ips.rb
@@ -84,7 +84,7 @@ class Benchmark::Output::Ips
       case scale
       when 1; 'k'
       when 2; 'M'
-      when 3; 'B'
+      when 3; 'G'
       when 4; 'T'
       when 5; 'Q'
       else # < 1000 or > 10^15, no scale or suffix

--- a/lib/benchmark/output/ips.rb
+++ b/lib/benchmark/output/ips.rb
@@ -98,13 +98,13 @@ class Benchmark::Output::Ips
     r = Rational(sec, iter)
     case
     when r >= 1
-      "#{'%3.2f' % r.to_f} sec"
+      "#{'%3.2f' % r.to_f}s"
     when r >= 1/1000r
-      "#{'%3.2f' % (r * 1_000).to_f} msec"
+      "#{'%3.2f' % (r * 1_000).to_f}ms"
     when r >= 1/1000_000r
-      "#{'%3.2f' % (r * 1_000_000).to_f} usec"
+      "#{'%3.2f' % (r * 1_000_000).to_f}us"
     else
-      "#{'%3.2f' % (r * 1_000_000_000).to_f} nsec"
+      "#{'%3.2f' % (r * 1_000_000_000).to_f}ns"
     end
   end
 


### PR DESCRIPTION
 show clocks if it is possible.

If /proc/cpuinfo is available and estimated clocks is under 1000,
show estimated clocks like that:

```
           0.times{}    57.468M i/s -    284.486M in 4.950325s (17.40ns/i, 50clocks/i)
           1.times{}    14.573M i/s -     81.655M in 5.603073s (68.62ns/i, 199clocks/i)
          10.times{}     2.979M i/s -     13.883M in 4.660414s (335.69ns/i, 974clocks/i)
         100.times{}   336.726k i/s -      1.678M in 4.983420s (2.97us/i)
        1000.times{}    28.508k i/s -    165.655k in 5.810803s (35.08us/i)
```