### PR TITLE
File.expand_path for relative path.

### DIFF
--- a/lib/benchmark/driver/configuration.rb
+++ b/lib/benchmark/driver/configuration.rb
@@ -25,6 +25,7 @@ class Benchmark::Driver::Configuration < Struct.new(:jobs, :runner_options, :out
   Executable = Struct.new(:name, :command) do
     def self.parse(name_path)
       name, path = name_path.split('::', 2)
+      path = File.expand_path(path)
       Benchmark::Driver::Configuration::Executable.new(name, path ? path.split(',') : [name])
     end
 


### PR DESCRIPTION
`Shellwords.shelljoin` escapes "~" character so that
we need to expand relative path before it. This fix
also enables to check binary file is available or not
(raise exception if specified ruby binary is not available).