### PR TITLE
Replace `#prelude=` with `#prelude` in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This interface generates code to profile with low overhead and executes it.
 require 'benchmark_driver'
 
 Benchmark.driver do |x|
-  x.prelude = <<~RUBY
+  x.prelude <<~RUBY
     require 'active_support/all'
     array = []
   RUBY
@@ -60,7 +60,7 @@ or simply:
 require 'benchmark_driver'
 
 Benchmark.driver do |x|
-  x.prelude = <<~RUBY
+  x.prelude <<~RUBY
     require 'active_support/all'
     array = []
   RUBY


### PR DESCRIPTION
`#prelude=` has been renamed to `#prelude` (without equal). See 959af3d19d8570bc58a0e7cf31fd994a153e4017
But `#prelude=` exist in the README.md. So this patch replaces the `#prelude=` with `#prelude`.

Close #25 