### PR TITLE
Raise ArgumentError when value is not positive

### DIFF
--- a/lib/benchmark_driver/output/compare.rb
+++ b/lib/benchmark_driver/output/compare.rb
@@ -104,8 +104,8 @@ class BenchmarkDriver::Output::Compare
   end
 
   def humanize(value, width = 10)
-    if value < 0
-      raise ArgumentError.new("Negative value: #{value.inspect}")
+    if value <= 0
+      raise ArgumentError.new("Non positive value: #{value.inspect}")
     end
 
     scale = (Math.log10(value) / 3).to_i


### PR DESCRIPTION
With this snippet,

```ruby
require 'benchmark_driver'

BenchmarkDriver::Output::Compare.new(jobs: nil, executables: nil).__send__(:humanize, 0.0)
```

## Actual

```
$ ruby test.rb
Traceback (most recent call last):
        2: from test.rb:3:in `<main>'
        1: from /Users/hkdnet/.ghq/github.com/hkdnet/benchmark_driver/lib/benchmark_driver/output/compare.rb:111:in `humanize'
/Users/hkdnet/.ghq/github.com/hkdnet/benchmark_driver/lib/benchmark_driver/output/compare.rb:111:in `to_i': -Infinity (FloatDomainError)
```

## Expected

Do not raise FloatDomainError

---

This occurred when `BenchmarkDriver::Metrics#value` is `0.0`.